### PR TITLE
Allow for fetching CHAR/VARCHAR data as binary data

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4528,6 +4528,7 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
     switch (col.ctype_)
     {
     case SQL_C_BINARY:
+    case SQL_C_CHAR:
     {
         if (!is_bound(column))
         {


### PR DESCRIPTION
As there's no way to provide a length otherwise, this assumes it's simply a null-terminated string, which in some (not very ideal) cases, it's not.

Treating it like binary data is an opt-in way to solve these issues.