### PR TITLE
Add bind_binary() for binding singular fields

### DIFF
--- a/nanodbc/nanodbc.h
+++ b/nanodbc/nanodbc.h
@@ -1366,6 +1366,33 @@ public:
 
     /// @}
 
+    /// \brief Binds binary data.
+    void bind_binary(
+        short param_index,
+        const uint8_t* value,
+        std::size_t value_size,
+        param_direction direction = PARAM_IN);
+
+    /// \brief Binds binary data.
+    void bind_binary(
+        short param_index,
+        std::vector<uint8_t> const& value,
+        param_direction direction = PARAM_IN);
+
+    /// \brief Binds binary data.
+    void bind_binary(
+        short param_index,
+        std::vector<uint8_t> const& value,
+        bool const* nulls,
+        param_direction direction = PARAM_IN);
+
+    /// \brief Binds binary data.
+    void bind_binary(
+        short param_index,
+        std::vector<uint8_t> const& value,
+        uint8_t const* null_sentry,
+        param_direction direction = PARAM_IN);
+
     /// \brief Sets descriptions for parameters in the prepared statement.
     ///
     /// If your prepared SQL query has any parameter markers, ? (question  mark)


### PR DESCRIPTION
bind() allows for multiple, but this would require wrapping the input, invoking unnecessary copies.

To avoid conflicting with any existing bind() implementations, I add the equivalent singular forms as bind_binary(), i.e.:

```cpp
    void bind_binary(
        short param_index,
        const uint8_t* value,
        std::size_t value_size,
        param_direction direction = PARAM_IN);

    void bind_binary(
        short param_index,
        std::vector<uint8_t> const& value,
        param_direction direction = PARAM_IN);

    void bind_binary(
        short param_index,
        std::vector<uint8_t> const& value,
        bool const* nulls,
        param_direction direction = PARAM_IN);

    void bind_binary(
        short param_index,
        std::vector<uint8_t> const& value,
        uint8_t const* null_sentry,
        param_direction direction = PARAM_IN);
```