### PR TITLE
Fix column size used in get_ref_impl<std::vector<uint8_t>>()

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -4523,7 +4523,7 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
     std::vector<std::uint8_t>& result) const
 {
     bound_column& col = bound_columns_[column];
-    const SQLULEN column_size = col.sqlsize_;
+    SQLULEN column_size = col.sqlsize_;
 
     switch (col.ctype_)
     {
@@ -4577,8 +4577,17 @@ inline void result::result_impl::get_ref_impl<std::vector<std::uint8_t>>(
         else
         {
             // Read fixed-length binary data
-            const char* s = col.pdata_ + rowset_position_ * col.clen_;
-            result.assign(s, s + column_size);
+            // Use the field's fetched length
+            column_size = col.cbdata_[static_cast<size_t>(rowset_position_)];
+            if (column_size > 0)
+            {
+                const char* s = col.pdata_ + rowset_position_ * col.clen_;
+                result.assign(s, s + column_size);
+            }
+            else
+            {
+                result.clear();
+            }
         }
         return;
     }


### PR DESCRIPTION
The column size used here is the full buffer size, rather than the size of the retrieved value.
This leads it to copy and assign junk memory, misleading the caller about the size and integrity of the returned data as it has no other way of knowing what its fetched size actually was.