### PR TITLE
Fix std::optional<> assignment

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3780,13 +3780,22 @@ public:
     template <class T, std::enable_if_t<is_optional<T>::value, int> = 0>
     void get_ref(short column, T& result) const
     {
+        using RealType = std::remove_reference_t<decltype(*result)>;
+
         throw_if_column_is_out_of_range(column);
         if (is_null(column))
         {
             opt_reset(result);
             return;
         }
-        get_ref_impl<std::remove_reference_t<decltype(*result)>>(column, *result);
+
+        RealType val = {};
+        get_ref_impl<RealType>(column, val);
+
+        if (is_null(column))
+            opt_reset(result);
+        else
+            result = std::move(val);
     }
 #endif
 
@@ -3830,13 +3839,22 @@ public:
     template <class T, std::enable_if_t<is_optional<T>::value, int> = 0>
     void get_ref(string const& column_name, T& result) const
     {
+        using RealType = std::remove_reference_t<decltype(*result)>;
+
         short const column = this->column(column_name);
         if (is_null(column))
         {
             opt_reset(result);
             return;
         }
-        get_ref_impl<std::remove_reference_t<decltype(*result)>>(column, *result);
+
+        RealType val = {};
+        get_ref_impl<RealType>(column, val);
+
+        if (is_null(column))
+            opt_reset(result);
+        else
+            result = std::move(val);
     }
 #endif
 


### PR DESCRIPTION
This code assumes that we're modifying an existing assigned value. If the value isn't set, this throws an assertion.

Instead, we fetch to a separate variable, then update result accordingly, depending on whether or not we fetched a null or not.