### PR TITLE
Add NANODBC_DISABLE_NULL_ACCESS_ERROR

### DIFF
--- a/nanodbc/nanodbc.cpp
+++ b/nanodbc/nanodbc.cpp
@@ -3772,7 +3772,14 @@ public:
     {
         throw_if_column_is_out_of_range(column);
         if (is_null(column))
+        {
+#ifdef NANODBC_DISABLE_NULL_ACCESS_ERROR
+            result = {};
+            return;
+#else
             throw null_access_error();
+#endif
+        }
         get_ref_impl<T>(column, result);
     }
 
@@ -3822,7 +3829,14 @@ public:
     {
         short const column = this->column(column_name);
         if (is_null(column))
+        {
+#ifdef NANODBC_DISABLE_NULL_ACCESS_ERROR
+            result = {};
+            return;
+#else
             throw null_access_error();
+#endif
+        }
         get_ref_impl<T>(column, result);
     }
 


### PR DESCRIPTION
Allow for initializing to defaults, rather than throwing on NULL.